### PR TITLE
move non app specific config options to global config file(s)

### DIFF
--- a/apps/database/config/config.exs
+++ b/apps/database/config/config.exs
@@ -33,9 +33,4 @@ config :database,
   namespace: Database,
   ecto_repos: [Database.Repo]
 
-# Configures Elixir's Logger
-config :logger, :console,
-  format: "$time $metadata[$level] $message\n",
-  metadata: [:user_id]
-
 import_config "#{Mix.env()}.exs"

--- a/apps/database/config/dev.exs
+++ b/apps/database/config/dev.exs
@@ -1,12 +1,5 @@
 use Mix.Config
 
-# Do not include metadata nor timestamps in development logs
-config :logger, :console, format: "[$level] $message\n"
-
-# Set a higher stacktrace during development. Avoid configuring such
-# in production as building large stacktraces may be expensive.
-config :phoenix, :stacktrace_depth, 20
-
 # Configure your database
 config :website, Database.Repo,
   adapter: Ecto.Adapters.Postgres,

--- a/apps/database/config/prod.exs
+++ b/apps/database/config/prod.exs
@@ -1,6 +1,3 @@
 use Mix.Config
 
-# no debug messages, in prod
-config :logger, level: :info
-
 import_config "prod.secret.exs"

--- a/apps/database/config/test.exs
+++ b/apps/database/config/test.exs
@@ -1,8 +1,5 @@
 use Mix.Config
 
-# Print only warnings and errors during test
-config :logger, level: :warn
-
 # Configure your database
 config :website, Database.Repo,
   adapter: Ecto.Adapters.Postgres,

--- a/apps/tag_editor/config/config.exs
+++ b/apps/tag_editor/config/config.exs
@@ -16,11 +16,6 @@ config :tag_editor, TagEditorWeb.Endpoint,
   render_errors: [view: TagEditorWeb.ErrorView, accepts: ~w(html json)],
   pubsub: [name: TagEditor.PubSub, adapter: Phoenix.PubSub.PG2]
 
-# Configures Elixir's Logger
-config :logger, :console,
-  format: "$time $metadata[$level] $message\n",
-  metadata: [:user_id]
-
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/apps/tag_editor/config/dev.exs
+++ b/apps/tag_editor/config/dev.exs
@@ -46,10 +46,3 @@ config :tag_editor, TagEditorWeb.Endpoint,
       ~r{lib/tag_editor_web/templates/.*(eex)$}
     ]
   ]
-
-# Do not include metadata nor timestamps in development logs
-config :logger, :console, format: "[$level] $message\n"
-
-# Set a higher stacktrace during development. Avoid configuring such
-# in production as building large stacktraces may be expensive.
-config :phoenix, :stacktrace_depth, 20

--- a/apps/tag_editor/config/prod.exs
+++ b/apps/tag_editor/config/prod.exs
@@ -18,9 +18,6 @@ config :tag_editor, TagEditorWeb.Endpoint,
   url: [host: "example.com", port: 80],
   cache_static_manifest: "priv/static/cache_manifest.json"
 
-# Do not print debug messages in production
-config :logger, level: :info
-
 # ## SSL Support
 #
 # To get SSL working, you will need to add the `https` key

--- a/apps/tag_editor/config/test.exs
+++ b/apps/tag_editor/config/test.exs
@@ -5,6 +5,3 @@ use Mix.Config
 config :tag_editor, TagEditorWeb.Endpoint,
   http: [port: 4001],
   server: false
-
-# Print only warnings and errors during test
-config :logger, level: :warn

--- a/apps/website/config/config.exs
+++ b/apps/website/config/config.exs
@@ -17,11 +17,6 @@ config :website, WebsiteWeb.Endpoint,
   pubsub: [name: Website.PubSub,
            adapter: Phoenix.PubSub.PG2]
 
-# Configures Elixir's Logger
-config :logger, :console,
-  format: "$time $metadata[$level] $message\n",
-  metadata: [:user_id]
-
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env}.exs"

--- a/apps/website/config/prod.exs
+++ b/apps/website/config/prod.exs
@@ -18,9 +18,6 @@ config :website, WebsiteWeb.Endpoint,
   url: [host: "example.com", port: 80],
   cache_static_manifest: "priv/static/cache_manifest.json"
 
-# Do not print debug messages in production
-config :logger, level: :info
-
 # ## SSL Support
 #
 # To get SSL working, you will need to add the `https` key

--- a/apps/website/config/test.exs
+++ b/apps/website/config/test.exs
@@ -5,6 +5,3 @@ use Mix.Config
 config :website, WebsiteWeb.Endpoint,
   http: [port: 4001],
   server: false
-
-# Print only warnings and errors during test
-config :logger, level: :warn

--- a/config/config.exs
+++ b/config/config.exs
@@ -15,3 +15,5 @@ import_config "../apps/*/config/config.exs"
 #       level: :info,
 #       format: "$date $time [$level] $metadata$message\n",
 #       metadata: [:user_id]
+
+import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,11 @@
+use Mix.Config
+
+# Set a higher stacktrace during development. Avoid configuring such
+# in production as building large stacktraces may be expensive.
+config :phoenix, :stacktrace_depth, 20
+
+# Configures Elixir's Logger
+config :logger, :console,
+  level: :info,
+  format: "$time $metadata [$level] $message\n",
+  metadata: [:user_id]

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,3 @@
+#use Mix.Config
+
+#TODO Configures Production Logger

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,13 @@
+use Mix.Config
+
+# Set a higher stacktrace during development. Avoid configuring such
+# in production as building large stacktraces may be expensive.
+config :phoenix, :stacktrace_depth, 20
+
+# Configures Elixir's Logger
+config :logger, :console,
+  level: :debug,
+  format: "$time $metadata[$level] $message\n",
+  metadata: [:user_id]
+
+config :ex_unit, capture_log: true


### PR DESCRIPTION
Different configurtion in the apps config.exs fucked each other.
This is an attempt to fix this.
Also it makes logging while testing better.
How we logging in prod is unclear.