### PR TITLE
add new OTP versions to the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ elixir:
   - '1.7'
   - '1.8'
 otp_release:
-  - '21.1'
   - '21.2'
+  - '21.3'
+  - '22.0'
 
 # Build only if the type of the job is not a push
 if: type != push

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Also, we currently lack github checks to do quality assurance on HTML, CSS, and 
 ## Travis
 We target the following versions of Elixir and OTP when building on Travis CI:
  - [Elixir](https://elixir-lang.org/): `1.7`, `1.8`
- - [OTP](https://github.com/erlang/otp): `21.1`, `21.2`
+ - [OTP](https://github.com/erlang/otp): `21.2`, `21.3`, `22.0`
 
 Travis checks that:
  - code compiles without warnings


### PR DESCRIPTION
Adds OTP 21.3 and 22.0 to travis builds, drops 21.1.

g2g, assuming docs are done