### PR TITLE
set TERM=xterm to allow basic functions in most terminal emulators

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -23,7 +23,7 @@ mkShell {
   # Set up environment vars
   # We unset TERM b/c of https://github.com/NixOS/nix/issues/1056
   shellHook = ''
-    unset TERM
+    export TERM=xterm
     export LANG="en_US.UTF-8"
     export LC_ALL="en_US.UTF-8"
   '';


### PR DESCRIPTION
This change allows using basic functions of terminal emulators like Ctrl-l, Ctrl-p, Ctrl-n (like in emacs).

I tested in kitty, roxterm and gnome-terminal.
That makes me think, it works most likely in most other terminal emulators too.
Should be good enough for this small project, tbh.